### PR TITLE
fix bug: helm chart yarn resource setting confingmap miss ","

### DIFF
--- a/helm-charts/Prophecis/templates/mllabis/yarn-resource-setting.yml
+++ b/helm-charts/Prophecis/templates/mllabis/yarn-resource-setting.yml
@@ -79,7 +79,7 @@ data:
           "base_url":"{{.Values.linkis.address}}",
           "headers": {
                 "Token-User":"hadoop",
-                "Token-Code": "{{.Values.linkis.tokenCode}}"
+                "Token-Code": "{{.Values.linkis.tokenCode}}",
                 "Content-Type":"application/json"
           },
           "session_configs": {


### PR DESCRIPTION
fix bug: helm chart yarn resource setting confingmap json miss ","