### PR TITLE
fix label name does not match

### DIFF
--- a/helm-charts/Prophecis/templates/cc/cc-deployment.yml
+++ b/helm-charts/Prophecis/templates/cc/cc-deployment.yml
@@ -4,7 +4,7 @@ metadata:
   name: controlcenter-go-deployment
   namespace: {{.Values.namespace}}
   labels: 
-    app: controlcenter-go-deployment
+    app: controlcenter-go
 spec:
   replicas: 1
   selector:

--- a/helm-charts/Prophecis/templates/cc/cc-gateway-deploy.yml
+++ b/helm-charts/Prophecis/templates/cc/cc-gateway-deploy.yml
@@ -4,7 +4,7 @@ metadata:
   name: controlcenter-gateway-deployment
   namespace: {{.Values.namespace}}
   labels:
-    app: controlcenter-gateway-deployment
+    app: controlcenter-gateway
 spec:
   replicas: 1
   selector:

--- a/helm-charts/Prophecis/templates/mllabis/aide-deployment.yml
+++ b/helm-charts/Prophecis/templates/mllabis/aide-deployment.yml
@@ -4,7 +4,7 @@ metadata:
   name: mllabis-deployment
   namespace: {{.Values.namespace}}
   labels: 
-    app: aide-deployment
+    app: aide
 spec:
   replicas: 1
   selector:

--- a/helm-charts/Prophecis/templates/ui/bdap-ui/bdap-ui-deployment.yml
+++ b/helm-charts/Prophecis/templates/ui/bdap-ui/bdap-ui-deployment.yml
@@ -5,6 +5,9 @@ metadata:
   namespace: {{.Values.namespace}}
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: bdap-ui
   template:
     metadata:
       labels:


### PR DESCRIPTION
The matchLabels has a redundant `-deployment` suffix, remove it to fix the error below:
```console
$ helm install prophecis . --namespace prophecis

Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: ValidationError(Deployment.spec): missing required field "selector" in io.k8s.api.apps.v1.DeploymentSpec
```